### PR TITLE
Remove minSdkVersion

### DIFF
--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -16,7 +16,7 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <platform name="android">
-        <preference name="android-minSdkVersion" value="14" />
+        <preference name="android-minSdkVersion" value="16" />
         <allow-intent href="market:*" />
     </platform>
     <platform name="ios">

--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -16,7 +16,6 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <platform name="android">
-        <preference name="android-minSdkVersion" value="16" />
         <allow-intent href="market:*" />
     </platform>
     <platform name="ios">


### PR DESCRIPTION
CordovaLib uses minSdkVersion 16, so the template doesn't build as it tries to use android-minSdkVersion 14.